### PR TITLE
Add time metrics for Sunrise, Solar Noon, Sunset, Moonrise, Moonset, Moon Phase.

### DIFF
--- a/src/DataSource.ts
+++ b/src/DataSource.ts
@@ -77,6 +77,9 @@ export class SunAndMoonDataSource extends DataSourceApi<SunAndMoonQuery, SunAndM
           case 'moon_illumination':
             value = SunCalc.getMoonIllumination(new Date(time)).fraction;
             break;
+          case 'moon_phase':
+            value = SunCalc.getMoonIllumination(new Date(time)).phase;
+            break;
           case 'moonrise': {
             let tmp = SunCalc.getMoonTimes(new Date(time), latitude!, longitude!).rise;
             value = tmp ? tmp.getTime() % (60 * 60 * 24 * 1000) : 0;

--- a/src/DataSource.ts
+++ b/src/DataSource.ts
@@ -77,11 +77,30 @@ export class SunAndMoonDataSource extends DataSourceApi<SunAndMoonQuery, SunAndM
           case 'moon_illumination':
             value = SunCalc.getMoonIllumination(new Date(time)).fraction;
             break;
+          case 'moonrise': {
+            let tmp = SunCalc.getMoonTimes(new Date(time), latitude!, longitude!).rise;
+            value = tmp ? tmp.getTime() % (60 * 60 * 24 * 1000) : 0;
+            break;
+          }
+          case 'moonset': {
+            let tmp = SunCalc.getMoonTimes(new Date(time), latitude!, longitude!).set;
+            value = tmp ? tmp.getTime() % (60 * 60 * 24 * 1000) : 0;
+            break;
+          }
+          case 'solar_noon':
+            value = SunCalc.getTimes(new Date(time), latitude!, longitude!).solarNoon.getTime() % (60 * 60 * 24 * 1000);
+            break;
+          case 'sunrise':
+            value = SunCalc.getTimes(new Date(time), latitude!, longitude!).sunrise.getTime() % (60 * 60 * 24 * 1000);
+            break;
+          case 'sunset':
+            value = SunCalc.getTimes(new Date(time), latitude!, longitude!).sunset.getTime() % (60 * 60 * 24 * 1000);
+            break;
           case 'moon_altitude':
             value = (SunCalc.getMoonPosition(new Date(time), latitude!, longitude!).altitude * 180) / Math.PI;
             break;
           case 'moon_azimuth':
-            value = (SunCalc.getMoonPosition(new Date(time), latitude!, longitude!).azimuth * 180) / Math.PI;
+            value = (SunCalc.getMoonPosition(new Date(time), latitude!, longitude!).azimuth * 180) / Math.PI + 180;
             break;
           case 'moon_distance':
             value = SunCalc.getMoonPosition(new Date(time), latitude!, longitude!).distance;
@@ -90,7 +109,7 @@ export class SunAndMoonDataSource extends DataSourceApi<SunAndMoonQuery, SunAndM
             value = (SunCalc.getPosition(new Date(time), latitude!, longitude!).altitude * 180) / Math.PI;
             break;
           case 'sun_azimuth':
-            value = (SunCalc.getPosition(new Date(time), latitude!, longitude!).azimuth * 180) / Math.PI;
+            value = (SunCalc.getPosition(new Date(time), latitude!, longitude!).azimuth * 180) / Math.PI + 180;
             break;
         }
         frame.add({ Time: time, Value: value });

--- a/src/__snapshots__/QueryEditor.test.tsx.snap
+++ b/src/__snapshots__/QueryEditor.test.tsx.snap
@@ -16,17 +16,42 @@ exports[`Render should render component 1`] = `
       options={
         Array [
           Object {
-            "description": "Percentage of the moon illuminated by the sun",
+            "description": "The time of the moon rising",
+            "label": "Moonrise",
+            "value": "moonrise",
+          },
+          Object {
+            "description": "The time of the moon setting",
+            "label": "Moonset",
+            "value": "moonset",
+          },
+          Object {
+            "description": "The time of solar noon",
+            "label": "Solar Noon",
+            "value": "solar_noon",
+          },
+          Object {
+            "description": "The time of sunrise",
+            "label": "Sunrise",
+            "value": "sunrise",
+          },
+          Object {
+            "description": "Time of sunset",
+            "label": "Sunset",
+            "value": "sunset",
+          },
+          Object {
+            "description": "Percentage of the moon illuminated by the sun (0.0-1.0)",
             "label": "Moon illumination",
             "value": "moon_illumination",
           },
           Object {
-            "description": "Height of the moon in the in degrees",
+            "description": "Height of the moon in degrees (-90-90)",
             "label": "Moon altitude",
             "value": "moon_altitude",
           },
           Object {
-            "description": "Direction of the moon along the horizon in degrees",
+            "description": "Direction of the moon along the horizon in degrees (0-360)",
             "label": "Moon azimuth",
             "value": "moon_azimuth",
           },
@@ -36,12 +61,12 @@ exports[`Render should render component 1`] = `
             "value": "moon_distance",
           },
           Object {
-            "description": "Height of the sun in the in degrees",
+            "description": "Height of the sun in degrees (-90-90)",
             "label": "Sun altitude",
             "value": "sun_altitude",
           },
           Object {
-            "description": "Direction of the sun along the horizon in degrees",
+            "description": "Direction of the sun along the horizon in degrees (0-360)",
             "label": "Sun azimuth",
             "value": "sun_azimuth",
           },

--- a/src/__snapshots__/QueryEditor.test.tsx.snap
+++ b/src/__snapshots__/QueryEditor.test.tsx.snap
@@ -46,6 +46,11 @@ exports[`Render should render component 1`] = `
             "value": "moon_illumination",
           },
           Object {
+            "description": "Moon phase (0 is New Moon, 0.25 is First Quarter, 0.5 is Full Moon, 0.75 is Last Quarter)",
+            "label": "Moon phase",
+            "value": "moon_phase",
+          },
+          Object {
             "description": "Height of the moon in degrees (-90-90)",
             "label": "Moon altitude",
             "value": "moon_altitude",

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,6 +25,10 @@ export const sunAndMoonMetrics: any = {
     title: 'Moon illumination',
     text: 'Percentage of the moon illuminated by the sun (0.0-1.0)',
   },
+  moon_phase: {
+    title: 'Moon phase',
+    text: 'Moon phase (0 is New Moon, 0.25 is First Quarter, 0.5 is Full Moon, 0.75 is Last Quarter)',
+  },
   moon_altitude: {
     title: 'Moon altitude',
     text: 'Height of the moon in degrees (-90-90)',

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,17 +1,37 @@
 import { DataQuery, DataSourceJsonData } from '@grafana/data';
 
 export const sunAndMoonMetrics: any = {
+  moonrise: {
+    title: 'Moonrise',
+    text: 'The time of the moon rising',
+  },
+  moonset: {
+    title: 'Moonset',
+    text: 'The time of the moon setting',
+  },
+  solar_noon: {
+    title: 'Solar Noon',
+    text: 'The time of solar noon',
+  },
+  sunrise: {
+    title: 'Sunrise',
+    text: 'The time of sunrise',
+  },
+  sunset: {
+    title: 'Sunset',
+    text: 'Time of sunset',
+  },
   moon_illumination: {
     title: 'Moon illumination',
-    text: 'Percentage of the moon illuminated by the sun',
+    text: 'Percentage of the moon illuminated by the sun (0.0-1.0)',
   },
   moon_altitude: {
     title: 'Moon altitude',
-    text: 'Height of the moon in the in degrees',
+    text: 'Height of the moon in degrees (-90-90)',
   },
   moon_azimuth: {
     title: 'Moon azimuth',
-    text: 'Direction of the moon along the horizon in degrees',
+    text: 'Direction of the moon along the horizon in degrees (0-360)',
   },
   moon_distance: {
     title: 'Moon distance',
@@ -19,11 +39,11 @@ export const sunAndMoonMetrics: any = {
   },
   sun_altitude: {
     title: 'Sun altitude',
-    text: 'Height of the sun in the in degrees',
+    text: 'Height of the sun in degrees (-90-90)',
   },
   sun_azimuth: {
     title: 'Sun azimuth',
-    text: 'Direction of the sun along the horizon in degrees',
+    text: 'Direction of the sun along the horizon in degrees (0-360)',
   },
 };
 


### PR DESCRIPTION
I've taken the liberty of adding the mentioned 6 metrics, the first 5 as millisecond values from 0-24h, the Moon Phase as described at https://github.com/mourner/suncalc#moon-illumination. They can be used to create a dashboard like the following:
![maim](https://user-images.githubusercontent.com/215510/158195969-d00b7c43-95af-4b57-8e55-41b80886e19f.png)


TODO:
- handle the case of no moonrise/-set in a better way, right now it just returns 0 (not sure how the grafana api works, so that I could return "no value" instead).
- add a setting for "height" in addition to lat/lon.